### PR TITLE
Remove type argument from structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.1.2
+## 0.1.3-dev.2
+
+Incorporate struct API changes (drop type argument of structs).
+
+## 0.1.3-dev.1
 
 * Adds top-level `allocate<T>()` and `free()` methods which can be used as a
   replacement for the deprecated `Pointer.allocate<T>()` and `Pointer.free()`

--- a/lib/src/utf16.dart
+++ b/lib/src/utf16.dart
@@ -13,7 +13,7 @@ import 'package:ffi/ffi.dart';
 ///
 /// [Utf16] is respresented as a struct so that `Pointer<Utf16>` can be used in
 /// native function signatures.
-class Utf16 extends Struct<Utf16> {
+class Utf16 extends Struct {
   /// Convert a [String] to a Utf16-encoded null-terminated C string.
   ///
   /// If 'string' contains NULL bytes, the converted string will be truncated

--- a/lib/src/utf8.dart
+++ b/lib/src/utf8.dart
@@ -20,7 +20,7 @@ final int _maxSize = sizeOf<IntPtr>() == 8 ? _kMaxSmi64 : _kMaxSmi32;
 //
 // TODO(https://github.com/dart-lang/ffi/issues/4): No need to use
 // 'asExternalTypedData' when Pointer operations are performant.
-class Utf8 extends Struct<Utf8> {
+class Utf8 extends Struct {
   /// Returns the length of a null-terminated string -- the number of (one-byte)
   /// characters before the first null byte.
   static int strlen(Pointer<Utf8> string) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ffi
-version: 0.1.3-dev.1
+version: 0.1.3-dev.2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.


### PR DESCRIPTION
This breaks the package in Dart 2.6.0-dev6 but allows us to land https://dart-review.googlesource.com/c/sdk/+/121422 by being able to pin the git hash of this commit in the DEPS file.

N.b. If we could pull this on a branch, we do not have to break the package.