### PR TITLE
Undo bump to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.4
+## 0.1.3-dev.4
 
 Bump SDK constraint to `>= 2.6.0-dev.8.2` which contains the new API of `dart:ffi`.
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,18 @@
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+main() {
+  // Allocate and free some native memory with malloc and free.
+  final pointer = allocate<Uint8>();
+  pointer.value = 3;
+  print(pointer.value);
+  free(pointer);
+
+  // Use the Utf8 helper to encode null-terminated Utf8 strings in native memory.
+  final String myString = "😎👿💬";
+  final Pointer<Utf8> charPointer = Utf8.toUtf8(myString);
+  print("First byte is: ${charPointer.cast<Uint8>().value}");
+  print(Utf8.fromUtf8(charPointer));
+  free(charPointer);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ffi
-version: 0.1.4
+version: 0.1.3-dev.4
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,6 @@ description: Utilities for working with Foreign Function Interface (FFI) code.
 
 environment:
   sdk: '>=2.6.0-dev.8.2 <3.0.0'
-documentation: https://pub.dev/documentation/ffi/
 
 dependencies:
 


### PR DESCRIPTION
Package stable versions should only depend on sdk stable versions.