### PR TITLE
Update SDK constraint to 2.6.0 stable and release 0.1.3 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.3
+
+Stable release incorporating all the previous dev release changes.
+
+Bump SDK constraint to `>= 2.6.0`.
+
 ## 0.1.3-dev.4
 
 Bump SDK constraint to `>= 2.6.0-dev.8.2` which contains the new API of `dart:ffi`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: ffi
-version: 0.1.3-dev.4
+version: 0.1.3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.
 
 environment:
-  sdk: '>=2.6.0-dev.8.2 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
 


### PR DESCRIPTION
Please wait with merging till 2.6 is out, so we can run Travis on it.