### PR TITLE
Utf8Pointer extension (#36), allocatedSize method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dart_tool
 .packages
 pubspec.lock
+doc/

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 Google LLC
+EPNW <prokopwieler.hardundsoftware@gmail.com>  

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -4,4 +4,4 @@
 
 export 'src/utf8.dart';
 export 'src/utf16.dart';
-export 'src/allocation.dart' show allocate, free;
+export 'src/allocation.dart' show allocate, free, allocatedSize;

--- a/lib/src/allocation.dart
+++ b/lib/src/allocation.dart
@@ -36,6 +36,15 @@ typedef WinHeapFree = int Function(Pointer heap, int flags, Pointer memory);
 final WinHeapFree winHeapFree =
     stdlib.lookupFunction<WinHeapFreeNative, WinHeapFree>("HeapFree");
 
+
+final Map<int, int> _sizeMap = new Map<int, int>();
+
+/// Returns the size that was allocated for a Pointer using the [allocate] method.
+///
+/// If the Pointer has already been freed or was not created using the [allocate] method,
+/// null is returned.
+int allocatedSize(Pointer p) => _sizeMap[p.address];
+
 /// Allocates memory on the native heap.
 ///
 /// For POSIX-based systems, this uses malloc. On Windows, it uses HeapAlloc
@@ -54,6 +63,7 @@ Pointer<T> allocate<T extends NativeType>({int count = 1}) {
   if (result.address == 0) {
     throw ArgumentError("Could not allocate $totalSize bytes.");
   }
+  _sizeMap[result.address] = totalSize;
   return result;
 }
 
@@ -75,4 +85,5 @@ void free(Pointer pointer) {
   } else {
     posixFree(pointer);
   }
+  _sizeMap.remove(pointer.address);
 }

--- a/lib/src/allocation.dart
+++ b/lib/src/allocation.dart
@@ -36,7 +36,6 @@ typedef WinHeapFree = int Function(Pointer heap, int flags, Pointer memory);
 final WinHeapFree winHeapFree =
     stdlib.lookupFunction<WinHeapFreeNative, WinHeapFree>("HeapFree");
 
-
 final Map<int, int> _sizeMap = new Map<int, int>();
 
 /// Returns the size that was allocated for a Pointer using the [allocate] method.


### PR DESCRIPTION
For getting the value, a simple getter `String get value => Utf8.fromUtf8(this);` was created.

When setting the value there are some restricitons on the length of the new String.
Therefore a map in `allocation.dart` was created, which stores the size of pointers created by the `allocate` method.
Then, when setting a new value, we can check if
a) the Pointer was allocated by the `allocate` method and the size of the new value does not exceed the allocated memory
or
b) the Pointer was not allocated by the `allocate` method but does not exceed the length of the current value