### PR TITLE
Fix utf8_test to match breaking change to UTF-8 encoding and decoding

### DIFF
--- a/test/utf8_test.dart
+++ b/test/utf8_test.dart
@@ -56,15 +56,14 @@ main() {
     final Pointer<Utf8> converted = Utf8.toUtf8(start).cast();
     final int length = Utf8.strlen(converted);
     final Uint8List end = converted.cast<Uint8>().asTypedList(length + 1);
-    expect(end, equals([237, 160, 128, 225, 128, 128, 0]));
+    expect(end, equals([239, 191, 189, 225, 128, 128, 0]));
     free(converted);
   });
 
   test("fromUtf8 unpaired surrogate", () {
     final Pointer<Utf8> utf8 =
         _bytesFromList([237, 160, 128, 225, 128, 128, 0]).cast();
-    final String end = Utf8.fromUtf8(utf8);
-    expect(end, equals(String.fromCharCodes([0xD800, 0x1000])));
+    expect(() => Utf8.fromUtf8(utf8), throwsA(isFormatException));
   });
 
   test("fromUtf8 invalid", () {

--- a/test/utf8_test.dart
+++ b/test/utf8_test.dart
@@ -51,21 +51,6 @@ main() {
     expect(end, "😎👿💬");
   });
 
-  test("toUtf8 unpaired surrogate", () {
-    final String start = String.fromCharCodes([0xD800, 0x1000]);
-    final Pointer<Utf8> converted = Utf8.toUtf8(start).cast();
-    final int length = Utf8.strlen(converted);
-    final Uint8List end = converted.cast<Uint8>().asTypedList(length + 1);
-    expect(end, equals([239, 191, 189, 225, 128, 128, 0]));
-    free(converted);
-  });
-
-  test("fromUtf8 unpaired surrogate", () {
-    final Pointer<Utf8> utf8 =
-        _bytesFromList([237, 160, 128, 225, 128, 128, 0]).cast();
-    expect(() => Utf8.fromUtf8(utf8), throwsA(isFormatException));
-  });
-
   test("fromUtf8 invalid", () {
     final Pointer<Utf8> utf8 = _bytesFromList([0x80, 0x00]).cast();
     expect(() => Utf8.fromUtf8(utf8), throwsA(isFormatException));


### PR DESCRIPTION
Change the expectations of the UTF-8 test to match the recent breaking change to the Dart UTF-8 encoding and decoding described here: https://github.com/dart-lang/sdk/issues/41100

This is necessary to unblock further rolls of the Dart SDK.