### PR TITLE
0.3.0-dev.0 Allocator and Opaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 
-## 0.3.0-dev.0
+## 0.3.0-nullsafety.0
 
 Changes `Utf8` and `Utf16` to extend `Opaque` instead of `Struct`.
 This means `.ref` is no longer available and `Pointer<Utf(..)>` should be used.
-See https://github.com/dart-lang/sdk/issues/44622 for more info.
+See [breaking change #44622](https://github.com/dart-lang/sdk/issues/44622) for more info.
 
 Removes `allocate` and `free`.
 Instead, introduces `calloc` which implements the new `Allocator` interface.
-See https://github.com/dart-lang/sdk/issues/44621 for more info.
+See [breaking change #44621](https://github.com/dart-lang/sdk/issues/44621) for more info.
 
-This dev release requires Dart `2.12.0-265.0.dev` or greater.
+This pre-release requires Dart `2.12.0-265.0.dev` or greater.
 
 ## 0.2.0-nullsafety.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.0-dev.0
+
+Changes `Utf8` and `Utf16` to extend `Opaque` instead of `Struct`.
+This means `.ref` is no longer available and `Pointer<Utf(..)>` should be used.
+See https://github.com/dart-lang/sdk/issues/44622 for more info.
+
+Removes `allocate` and `free`.
+Instead, introduces `calloc` which implements the new `Allocator` interface.
+See https://github.com/dart-lang/sdk/issues/44621 for more info.
+
+This dev release requires Dart `2.12.0-265.0.dev` or greater.
+
 ## 0.2.0-nullsafety.1
 
 Adds an optional named `length` argument to `Utf8.fromUtf8()`.

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,6 +1,6 @@
 import 'dart:ffi';
 
-import 'package:ffi/ffi.dart' hide allocate;
+import 'package:ffi/ffi.dart';
 
 void main() {
   // Allocate and free some native memory with calloc and free.

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,18 +1,18 @@
 import 'dart:ffi';
 
-import 'package:ffi/ffi.dart';
+import 'package:ffi/ffi.dart' hide allocate;
 
 void main() {
   // Allocate and free some native memory with malloc and free.
-  final pointer = allocate<Uint8>();
+  final pointer = allocate<Uint8>(malloc);
   pointer.value = 3;
   print(pointer.value);
-  free(pointer);
+  malloc.free(pointer);
 
   // Use the Utf8 helper to encode zero-terminated UTF-8 strings in native memory.
   final String myString = '😎👿💬';
   final Pointer<Utf8> charPointer = Utf8.toUtf8(myString);
   print('First byte is: ${charPointer.cast<Uint8>().value}');
   print(Utf8.fromUtf8(charPointer));
-  free(charPointer);
+  malloc.free(charPointer);
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,6 +1,6 @@
 import 'dart:ffi';
 
-import 'package:ffi/ffi.dart' hide allocate;
+import 'package:ffi/ffi.dart';
 
 void main() {
   // Allocate and free some native memory with malloc and free.

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -4,4 +4,4 @@
 
 export 'src/utf8.dart';
 export 'src/utf16.dart';
-export 'src/allocation.dart' show allocate, free;
+export 'src/allocation.dart' show allocate, free, malloc;

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -4,4 +4,4 @@
 
 export 'src/utf8.dart';
 export 'src/utf16.dart';
-export 'src/allocation.dart' show allocate, free, calloc, malloc;
+export 'src/allocation.dart' show calloc, malloc;

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -4,4 +4,4 @@
 
 export 'src/utf8.dart';
 export 'src/utf16.dart';
-export 'src/allocation.dart' show allocate, free, malloc;
+export 'src/allocation.dart' show malloc;

--- a/lib/src/allocation.dart
+++ b/lib/src/allocation.dart
@@ -36,32 +36,6 @@ typedef WinHeapFree = int Function(Pointer heap, int flags, Pointer memory);
 final WinHeapFree winHeapFree =
     stdlib.lookupFunction<WinHeapFreeNative, WinHeapFree>('HeapFree');
 
-/// Allocates memory on the native heap.
-///
-/// For POSIX-based systems, this uses malloc. On Windows, it uses HeapAlloc
-/// against the default public heap. Allocation of either element size or count
-/// of 0 is undefined.
-///
-/// Throws an ArgumentError on failure to allocate.
-@Deprecated('Use malloc.allocate instead.')
-Pointer<T> allocate<T extends NativeType>({int count = 1}) {
-  final int totalSize = count * sizeOf<T>();
-  return malloc.allocate(totalSize);
-}
-
-/// Releases memory on the native heap.
-///
-/// For POSIX-based systems, this uses free. On Windows, it uses HeapFree
-/// against the default public heap. It may only be used against pointers
-/// allocated in a manner equivalent to [allocate].
-///
-/// Throws an ArgumentError on failure to free.
-///
-// TODO(dartbug.com/36855): Once we have a ffi.Bool type we can use it instead
-// of testing the return integer to be non-zero.
-@Deprecated('Use malloc.free instead.')
-void free(Pointer pointer) => malloc.free(pointer);
-
 /// Manages memory on the native heap.
 ///
 /// For POSIX-based systems, this uses malloc and free. On Windows, it uses

--- a/lib/src/allocation.dart
+++ b/lib/src/allocation.dart
@@ -75,7 +75,9 @@ class MallocAllocator implements Allocator {
   /// against the default public heap.
   ///
   /// Throws an ArgumentError on failure to allocate.
-  Pointer<T> allocate<T extends NativeType>(int numBytes) {
+  // TODO: Stop ignoring alignment if it's large, for example for SSE data.
+  @override
+  Pointer<T> allocate<T extends NativeType>(int numBytes, {int? alignment}) {
     Pointer<T> result;
     if (Platform.isWindows) {
       result = winHeapAlloc(processHeap, /*flags=*/ 0, numBytes).cast();
@@ -98,6 +100,7 @@ class MallocAllocator implements Allocator {
   ///
   // TODO(dartbug.com/36855): Once we have a ffi.Bool type we can use it instead
   // of testing the return integer to be non-zero.
+  @override
   void free(Pointer pointer) {
     if (Platform.isWindows) {
       if (winHeapFree(processHeap, /*flags=*/ 0, pointer) == 0) {

--- a/lib/src/allocation.dart
+++ b/lib/src/allocation.dart
@@ -66,7 +66,9 @@ void free(Pointer pointer) => malloc.free(pointer);
 ///
 /// For POSIX-based systems, this uses malloc and free. On Windows, it uses
 /// HeapAlloc and HeapFree against the default public heap.
-class MallocAllocator extends Allocator {
+class MallocAllocator implements Allocator {
+  const MallocAllocator();
+
   /// Allocates memory on the native heap.
   ///
   /// For POSIX-based systems, this uses malloc. On Windows, it uses HeapAlloc
@@ -107,4 +109,4 @@ class MallocAllocator extends Allocator {
   }
 }
 
-final malloc = MallocAllocator();
+const malloc = MallocAllocator();

--- a/lib/src/allocation.dart
+++ b/lib/src/allocation.dart
@@ -43,32 +43,6 @@ final WinHeapFree winHeapFree =
 
 const int HEAP_ZERO_MEMORY = 8;
 
-/// Allocates memory on the native heap.
-///
-/// For POSIX-based systems, this uses calloc. On Windows, it uses HeapAlloc
-/// against the default public heap. Allocation of either element size or count
-/// of 0 is undefined.
-///
-/// Throws an ArgumentError on failure to allocate.
-@Deprecated('Use calloc.allocate instead.')
-Pointer<T> allocate<T extends NativeType>({int count = 1}) {
-  final int totalSize = count * sizeOf<T>();
-  return calloc.allocate(totalSize);
-}
-
-/// Releases memory on the native heap.
-///
-/// For POSIX-based systems, this uses free. On Windows, it uses HeapFree
-/// against the default public heap. It may only be used against pointers
-/// allocated in a manner equivalent to [allocate].
-///
-/// Throws an ArgumentError on failure to free.
-///
-// TODO(dartbug.com/36855): Once we have a ffi.Bool type we can use it instead
-// of testing the return integer to be non-zero.
-@Deprecated('Use calloc.free instead.')
-void free(Pointer pointer) => calloc.free(pointer);
-
 /// Manages memory on the native heap.
 ///
 /// Does not initialize newly allocated memory to zero. Use [_CallocAllocator]

--- a/lib/src/utf16.dart
+++ b/lib/src/utf16.dart
@@ -5,7 +5,7 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:ffi/ffi.dart';
+import 'package:ffi/ffi.dart' hide allocate;
 
 /// [Utf16] implements conversion between Dart strings and zero-terminated
 /// UTF-16 encoded "char*" strings in C.
@@ -19,10 +19,10 @@ class Utf16 extends Struct {
   /// prematurely. Unpaired surrogate code points in [string] will be preserved
   /// in the UTF-16 encoded result. See [Utf16Encoder] for details on encoding.
   ///
-  /// Returns a malloc-allocated pointer to the result.
-  static Pointer<Utf16> toUtf16(String string) {
+  /// Returns a [allocator]-allocated pointer to the result.
+  static Pointer<Utf16> toUtf16(String string, {Allocator allocator = malloc}) {
     final units = string.codeUnits;
-    final Pointer<Uint16> result = allocate<Uint16>(count: units.length + 1);
+    final Pointer<Uint16> result = allocate<Uint16>(allocator, count: units.length + 1);
     final Uint16List nativeString = result.asTypedList(units.length + 1);
     nativeString.setAll(0, units);
     nativeString[units.length] = 0;

--- a/lib/src/utf8.dart
+++ b/lib/src/utf8.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:ffi/ffi.dart';
+import 'package:ffi/ffi.dart' hide allocate;
 
 const int _kMaxSmi64 = (1 << 62) - 1;
 const int _kMaxSmi32 = (1 << 30) - 1;
@@ -54,10 +54,10 @@ class Utf8 extends Struct {
   /// as replacement characters (U+FFFD, encoded as the bytes 0xEF 0xBF 0xBD)
   /// in the UTF-8 encoded result. See [Utf8Encoder] for details on encoding.
   ///
-  /// Returns a malloc-allocated pointer to the result.
-  static Pointer<Utf8> toUtf8(String string) {
+  /// Returns a [allocator]-allocated pointer to the result.
+  static Pointer<Utf8> toUtf8(String string, {Allocator allocator = malloc}) {
     final units = utf8.encode(string);
-    final Pointer<Uint8> result = allocate<Uint8>(count: units.length + 1);
+    final Pointer<Uint8> result = allocate<Uint8>(allocator, count: units.length + 1);
     final Uint8List nativeString = result.asTypedList(units.length + 1);
     nativeString.setAll(0, units);
     nativeString[units.length] = 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: ffi
-version: 0.2.0-nullsafety.1
+version: 0.3.0-dev.0
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0-265.0.dev <3.0.0'
 
 # dependencies:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ffi
-version: 0.3.0-dev.0
+version: 0.3.0-nullsafety.0
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.
 

--- a/test/utf16_test.dart
+++ b/test/utf16_test.dart
@@ -5,7 +5,7 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:ffi/ffi.dart';
+import 'package:ffi/ffi.dart' hide allocate;
 import 'package:test/test.dart';
 
 void main() {
@@ -15,7 +15,7 @@ void main() {
     final Uint16List end = converted.asTypedList(start.codeUnits.length + 1);
     final matcher = equals(start.codeUnits.toList()..add(0));
     expect(end, matcher);
-    free(converted);
+    malloc.free(converted);
   });
 
   test('toUtf16 emoji', () {
@@ -25,6 +25,6 @@ void main() {
     final Uint16List end = converted.cast<Uint16>().asTypedList(length + 1);
     final matcher = equals(start.codeUnits.toList()..add(0));
     expect(end, matcher);
-    free(converted);
+    malloc.free(converted);
   });
 }

--- a/test/utf8_test.dart
+++ b/test/utf8_test.dart
@@ -5,11 +5,11 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:ffi/ffi.dart';
+import 'package:ffi/ffi.dart' hide allocate;
 import 'package:test/test.dart';
 
 Pointer<Uint8> _bytesFromList(List<int> ints) {
-  final Pointer<Uint8> ptr = allocate(count: ints.length);
+  final Pointer<Uint8> ptr = allocate(malloc, count: ints.length);
   final Uint8List list = ptr.asTypedList(ints.length);
   list.setAll(0, ints);
   return ptr;
@@ -23,7 +23,7 @@ void main() {
     final matcher =
         equals([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 10, 0]);
     expect(end, matcher);
-    free(converted);
+    malloc.free(converted);
   });
 
   test('fromUtf8 ASCII', () {
@@ -41,7 +41,7 @@ void main() {
     final matcher =
         equals([240, 159, 152, 142, 240, 159, 145, 191, 240, 159, 146, 172, 0]);
     expect(end, matcher);
-    free(converted);
+    malloc.free(converted);
   });
 
   test('formUtf8 emoji', () {


### PR DESCRIPTION
Making a release to address https://github.com/flutter/flutter/issues/75113 and https://github.com/dart-lang/ffi/issues/71.

The CI is failing to run the dev build, because we haven't released this version. *"The current Dart SDK version is 2.12.0-259.0.dev."* I want to release a version anyway, because we have users on Flutter-master which _do_ have this version.

@mit-mit This is a PR to master, but if we want to keep master only for stable/beta builds we could create a dart-dev branch here instead. (That is what we've done in package:ffigen: https://github.com/dart-lang/ffigen/tree/dart-dev.)

Note that we cannot pin this package release in the Dart SDK yet, because Flutter in g3 does not contain `2.12.0-265.0.dev` yet.