### PR TITLE
Release for 2.12.0-259.8.beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.0-nullsafety.1
+
+This pre-release requires Dart `2.12.0-259.8.beta` or greater.
+
+Note that this pre-release does _not_ work in Flutter versions containing Dart
+`2.12.0-260.0.dev` - `2.12.0-264.0.dev`.
+Using `Allocator.call` throws a `NoSuchMethodError` in these versions.
+See [Flutter Engine #23954](https://github.com/flutter/engine/pull/23954) for more info.
+
 ## 0.3.0-nullsafety.0
 
 Changes `Utf8` and `Utf16` to extend `Opaque` instead of `Struct`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: ffi
-version: 0.3.0-nullsafety.0
+version: 0.3.0-nullsafety.1
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.
 
 environment:
-  sdk: '>=2.12.0-265.0.dev <3.0.0'
+  sdk: '>=2.12.0-259.8.beta <3.0.0'
 
 # dependencies:
 


### PR DESCRIPTION
This Dart version contains the cherry pick for https://github.com/dart-lang/sdk/issues/44822 (in https://github.com/dart-lang/sdk/commit/e5dd92c3ca766810e0e5a02d8725b1cebc19f564) in Dart standalone.

This Dart version will contain and https://github.com/flutter/engine/pull/23954 (in https://github.com/flutter/engine/pull/24142).