### PR TITLE
Export `allocate` and `free`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0-nullsafety.2
+## 0.3.0-nullsafety.3
 
 Adds back in deprecated `allocate` and `free` to ease migration.
 These will be removed in the next release.

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -4,4 +4,5 @@
 
 export 'src/utf8.dart';
 export 'src/utf16.dart';
+// ignore: deprecated_member_use_from_same_package
 export 'src/allocation.dart' show allocate, free, calloc, malloc;

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -4,4 +4,4 @@
 
 export 'src/utf8.dart';
 export 'src/utf16.dart';
-export 'src/allocation.dart' show calloc, malloc;
+export 'src/allocation.dart' show allocate, free, calloc, malloc;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ffi
-version: 0.3.0-nullsafety.2
+version: 0.3.0-nullsafety.3
 homepage: https://github.com/dart-lang/ffi
 description: Utilities for working with Foreign Function Interface (FFI) code.
 


### PR DESCRIPTION
Fix for step 1 in #82.